### PR TITLE
Fix CBBA multi-hop consensus and bundle management 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+- **CBBA (`cbba.py`)**
+  - **Bundle management**: Changed bundle construction to use `append` instead of `insert`, and when outbid, all tasks after the outbid task are now removed from the bundle.
+  - **Multi-hop information propagation**: Fixed three issues that prevented consensus information from propagating beyond 1-hop neighbors:
+    1. `message_to_share` (y, z, s) was only broadcast during BUILD_BUNDLE phase — added broadcast after ASSIGNMENT_CONSENSUS phase as well.
+    2. `update_time_stamp()` was called before conflict resolution, causing `s_km > s_im` (Table I) to always be false. Moved to after conflict resolution per Eqn (5).
+    3. Removed overly restrictive skip condition (`if j not in y_k or j not in y_i`) that prevented Table I rules (e.g., Rule 4, 13) from firing when `z_ij = None`.
+  - These fixes eliminate the occurrence of unassigned tasks (as long as all agents are connected).
+
 ### Added
 - **New Scenario: Turtle Catcher (`scenarios/features/turtle_catcher/`)**
   - Added as a direct counterpart to `py_bt_ros/scenarios/example_turtlesim`, enabling the same BT logic to be tested in simulation before porting to ROS.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@
     3. Removed overly restrictive skip condition (`if j not in y_k or j not in y_i`) that prevented Table I rules (e.g., Rule 4, 13) from firing when `z_ij = None`.
   - These fixes eliminate the occurrence of unassigned tasks (as long as all agents are connected).
 
+### Changed
+- **Base Simulation (`base_sim.py`)**
+  - Extracted status text rendering into overridable `draw_status_overlay()` method, allowing scenario-specific subclasses to customise the HUD overlay.
+
 ### Added
 - **New Scenario: Turtle Catcher (`scenarios/features/turtle_catcher/`)**
   - Added as a direct counterpart to `py_bt_ros/scenarios/example_turtlesim`, enabling the same BT logic to be tested in simulation before porting to ROS.
@@ -71,7 +75,8 @@
 
 - **Scenario: Simple**
   - Added `IsTaskCompleted`, `IsArrivedAtTarget`, `MoveToTarget`, and `ExecuteTask` to the simple scenario. These replace the functionality of `TaskExecutingNode`, which has been removed.   
-  - Renamed `ExplorationNode` to `Explore()` following the new naming convention (using verb forms).     
+  - Renamed `ExplorationNode` to `Explore()` following the new naming convention (using verb forms).
+  - Overrode `draw_status_overlay()` to display assigned tasks count (from `planned_tasks`) and communication connectivity status (BFS-based Connected/Not Connected indicator).     
 
 - **Environment**
   - Modified `env.reset()` to restart with a new random scenario.  

--- a/modules/base_sim.py
+++ b/modules/base_sim.py
@@ -161,6 +161,10 @@ class BaseSim:
             task.draw(self.screen)
 
 
+    def draw_status_overlay(self):
+        task_time_text = pre_render_text(f'Tasks left: {self.tasks_left}; Time: {self.simulation_time:.2f}s', 36, (0, 0, 0))
+        self.screen.blit(task_time_text, (self.screen_width - 350, 20))
+
     def render(self):
         if self.rendering_mode == "Screen" and self.screen:
             # Draw background
@@ -174,9 +178,7 @@ class BaseSim:
             self.draw_agents_info()
             self.draw_agents()
 
-            # Display task quantity and elapsed simulation time                
-            task_time_text = pre_render_text(f'Tasks left: {self.tasks_left}; Time: {self.simulation_time:.2f}s', 36, (0, 0, 0))
-            self.screen.blit(task_time_text, (self.screen_width - 350, 20))
+            self.draw_status_overlay()
 
 
             # # Call draw_decision_making_status from the imported module if it exists

--- a/plugins/cbba/cbba.py
+++ b/plugins/cbba/cbba.py
@@ -58,8 +58,8 @@ class CBBA:
         self.assigned_task = local_tasks_info.get(previous_assigned_task_id)        
         if self.assigned_task is None and previous_assigned_task_id is not None: 
             if len(self.path) != 0 and self.path[0].task_id == previous_assigned_task_id:
-                self.path.pop(0)
-                self.bundle.pop(0)
+                completed_task_id = self.path.pop(0).task_id
+                self.bundle.remove(completed_task_id)
             self.phase = Phase.BUILD_BUNDLE
 
         if len(self.bundle) == 0:
@@ -101,7 +101,7 @@ class CBBA:
             return None
         
         if self.phase == Phase.ASSIGNMENT_CONSENSUS:
-            self.update_time_stamp()
+            # self.update_time_stamp() # NOTE: Moved after conflict resolution. s_i must reflect prior knowledge during Table I comparisons (s_km > s_im), otherwise merging s_k beforehand makes the comparison always false.
             # Phase 2 Consensus
             candidates = list(local_tasks_info.values()) if isinstance(local_tasks_info, dict) else local_tasks_info            
             
@@ -131,9 +131,9 @@ class CBBA:
                     s_k = parsed_msg['s_k']
                     k_agent_id = parsed_msg['agent_id']
                     
-                    # Skip if task is not in both bid lists
-                    if j not in y_k or j not in y_i:
-                        continue
+                    # # Skip if task is not in both bid lists
+                    # if j not in y_k or j not in y_i: # NOTE: Commented out - this prevents Table I rules (e.g., Rule 4, 13) from firing when z_ij=None. The z_i.get(j) checks handle missing y_i[j] implicitly.
+                    #     continue
 
                     try:    
                         if z_k.get(j) == k_agent_id:
@@ -231,11 +231,23 @@ class CBBA:
                     except Exception as e:
                         pass
 
+            # Update time stamp after conflict resolution (Eqn 5)
+            self.update_time_stamp()
+
             # Bundle Update
             updated_bundle, updated_path = self.update_bundle_and_path()
             
             # Reset Message
             # self.agent.reset_messages_received()
+
+            # Broadcast updated y, z, s for multi-hop propagation
+            self.agent.message_to_share.update({
+                'winning_agents': copy.deepcopy(self.z),
+                'winning_bids': copy.deepcopy(self.y),
+                'message_received_time_stamp': copy.deepcopy(self.s)
+            })
+
+
             if WINNING_BID_CANCEL:
                 if len(updated_bundle) > 0:
                     self.no_bundle_duration = 0
@@ -283,8 +295,14 @@ class CBBA:
                 _n_bar = idx
                 break
 
+        _tasks_to_remove = set(self.bundle[_n_bar:])
+        for _task_id in _tasks_to_remove:
+            if self.z.get(_task_id) == self.agent.agent_id:
+                self.y[_task_id] = float('-inf')
+                self.z[_task_id] = None
+
         _bundle = self.bundle[0:_n_bar]
-        _path = self.path[0:_n_bar]
+        _path = [t for t in self.path if t.task_id not in _tasks_to_remove]
 
         return _bundle, _path
 
@@ -315,7 +333,8 @@ class CBBA:
             best_insertion_idx = best_insertion_idx_list[task_to_add.task_id]
 
             # Line 11
-            self.bundle.insert(best_insertion_idx, task_to_add.task_id)
+            # self.bundle.insert(best_insertion_idx, task_to_add.task_id)
+            self.bundle.append(task_to_add.task_id)
             # Line 12
             self.path.insert(best_insertion_idx, task_to_add)
             # Line 13

--- a/scenarios/simple/sim/sim.py
+++ b/scenarios/simple/sim/sim.py
@@ -1,5 +1,5 @@
 from modules.base_sim import BaseSim
-from modules.utils import ResultSaver, config, generate_positions
+from modules.utils import ResultSaver, config, generate_positions, pre_render_text
 from scenarios.simple.sim.task import Task
 from scenarios.simple.sim.agent import Agent
 
@@ -77,3 +77,24 @@ class Sim(BaseSim):
             tasks_total_amount_left
         ])        
                   
+
+    def draw_status_overlay(self):
+        # Display task quantity, assigned tasks, and elapsed simulation time
+        # NOTE: 'Assigned' count is only valid in CBBA mode (other plugins may not update planned_tasks consistently)
+        assigned_tasks = len({task.task_id for agent in self.agents for task in agent.planned_tasks})
+        task_time_text = pre_render_text(f'Tasks left: {self.tasks_left}; Assigned: {assigned_tasks}; Time: {self.simulation_time:.2f}s', 36, (0, 0, 0))
+        self.screen.blit(task_time_text, (self.screen_width - 450, 20))
+
+        # Check communication connectivity (BFS)
+        visited = {0}
+        queue = [0]
+        while queue:
+            for n in self.agents[queue.pop(0)].agents_nearby:
+                if n.agent_id not in visited:
+                    visited.add(n.agent_id)
+                    queue.append(n.agent_id)
+        if len(visited) == len(self.agents):
+            conn_text = pre_render_text('Connected', 28, (0, 150, 0))
+        else:
+            conn_text = pre_render_text('Not Connected', 28, (200, 0, 0))
+        self.screen.blit(conn_text, (self.screen_width - 450, 50))


### PR DESCRIPTION
### Fixed
- **CBBA (`cbba.py`)**
  - **Bundle management**: Changed bundle construction to use `append` instead of `insert`, and when outbid, all tasks after the outbid task are now removed from the bundle.
  - **Multi-hop information propagation**: Fixed three issues that prevented consensus information from propagating beyond 1-hop neighbors:
    1. `message_to_share` (y, z, s) was only broadcast during BUILD_BUNDLE phase — added broadcast after ASSIGNMENT_CONSENSUS phase as well.
    2. `update_time_stamp()` was called before conflict resolution, causing `s_km > s_im` (Table I) to always be false. Moved to after conflict resolution per Eqn (5).
    3. Removed overly restrictive skip condition (`if j not in y_k or j not in y_i`) that prevented Table I rules (e.g., Rule 4, 13) from firing when `z_ij = None`.
  - These fixes eliminate the occurrence of unassigned tasks (as long as all agents are connected).